### PR TITLE
Add 'crio dedup' command with FIEMAP physical disk usage reporting

### DIFF
--- a/cmd/crio/main.go
+++ b/cmd/crio/main.go
@@ -162,6 +162,7 @@ func main() {
 	app.Commands = append(app.Commands,
 		criocli.CheckCommand,
 		criocli.ConfigCommand,
+		criocli.DedupCommand,
 		criocli.PublishCommand,
 		criocli.StatusCommand,
 		criocli.VersionCommand,

--- a/completions/bash/crio
+++ b/completions/bash/crio
@@ -6,6 +6,7 @@ _cli_bash_autocomplete() {
 complete
 completion
 config
+dedup
 man
 markdown
 md

--- a/completions/fish/crio.fish
+++ b/completions/fish/crio.fish
@@ -2,7 +2,7 @@
 
 function __fish_crio_no_subcommand --description 'Test if there has been any subcommand yet'
     for i in (commandline -opc)
-        if contains -- $i check complete completion help h config man markdown md status config c containers container cs s info i goroutines g heap hp version wipe help h
+        if contains -- $i check complete completion help h config dedup man markdown md status config c containers container cs s info i goroutines g heap hp version wipe help h
             return 1
         end
     end
@@ -224,6 +224,9 @@ complete -r -c crio -n '__fish_crio_no_subcommand' -a 'config' -d 'Outputs a com
 by CRI-O. This allows you to save you current configuration setup and then load
 it later with **--config**. Global options will modify the output.'
 complete -c crio -n '__fish_seen_subcommand_from config' -f -l default -d 'Output the default configuration (without taking into account any configuration options).'
+complete -c crio -n '__fish_seen_subcommand_from dedup' -f -l help -s h -d 'show help'
+complete -r -c crio -n '__fish_crio_no_subcommand' -a 'dedup' -d 'deduplicate image storage using reflinks'
+complete -c crio -n '__fish_seen_subcommand_from dedup' -f -l physical-disk-usage -s p -d 'report real physical disk usage after dedup (FIEMAP-based, Linux only)'
 complete -c crio -n '__fish_seen_subcommand_from man' -f -l help -s h -d 'show help'
 complete -r -c crio -n '__fish_crio_no_subcommand' -a 'man' -d 'Generate the man page documentation.'
 complete -c crio -n '__fish_seen_subcommand_from markdown md' -f -l help -s h -d 'show help'

--- a/completions/zsh/_crio
+++ b/completions/zsh/_crio
@@ -26,6 +26,7 @@ best if CRI-O and any currently running containers are stopped."
         'config:Outputs a commented version of the configuration file that could be used
 by CRI-O. This allows you to save you current configuration setup and then load
 it later with **--config**. Global options will modify the output.'
+        'dedup:deduplicate image storage using reflinks'
         'man:Generate the man page documentation.'
         'markdown:Generate the markdown documentation.'
         'md:Generate the markdown documentation.'

--- a/docs/crio.8.md
+++ b/docs/crio.8.md
@@ -429,9 +429,9 @@ crio [GLOBAL OPTIONS] command [COMMAND OPTIONS] [ARGUMENTS...]
 
 **--read-only**: Setup all unprivileged containers to run as read-only. Automatically mounts the containers' tmpfs on '/run', '/tmp' and '/var/tmp'.
 
-**--root, -r**="": The CRI-O root directory. (default: "/var/lib/containers/storage")
+**--root, -r**="": The CRI-O root directory. (default: "/home/core/.local/share/containers/storage")
 
-**--runroot**="": The CRI-O state directory. (default: "/run/containers/storage")
+**--runroot**="": The CRI-O state directory. (default: "/run/user/1001/containers")
 
 **--runtimes**="": OCI runtimes, format is 'runtime_name:runtime_path:runtime_root:runtime_type:privileged_without_host_devices:runtime_config_path:container_min_memory'.
 
@@ -533,6 +533,12 @@ by CRI-O. This allows you to save you current configuration setup and then load
 it later with **--config**. Global options will modify the output.
 
 **--default**: Output the default configuration (without taking into account any configuration options).
+
+## dedup
+
+deduplicate image storage using reflinks
+
+**--physical-disk-usage, -p**: report real physical disk usage after dedup (FIEMAP-based, Linux only)
 
 ## man
 

--- a/internal/criocli/dedup.go
+++ b/internal/criocli/dedup.go
@@ -1,0 +1,61 @@
+package criocli
+
+import (
+	"fmt"
+
+	"github.com/urfave/cli/v2"
+
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/server"
+)
+
+// DedupCommand is the `crio dedup` subcommand for running storage
+// deduplication on demand. It opens the storage, runs deduplication
+// using reflinks, and reports the result. This should be run while
+// CRI-O is stopped to avoid lock contention with image pulls.
+var DedupCommand = &cli.Command{
+	Name:  "dedup",
+	Usage: "deduplicate image storage using reflinks",
+	Description: `Deduplicate identical files across container image layers using
+filesystem-level reflinks (copy-on-write clones). This reduces disk
+usage without the drawbacks of hard links, as modifying one copy does
+not affect others.
+
+Requires a filesystem that supports reflinks (e.g., XFS with reflink=1
+or Btrfs). On unsupported filesystems, the command exits with an error.
+
+This command should be run while CRI-O is stopped to avoid lock
+contention with image pull operations.`,
+	Action: crioDedup,
+	Flags: []cli.Flag{
+		&cli.BoolFlag{
+			Name:    "physical-disk-usage",
+			Aliases: []string{"p"},
+			Usage:   "report real physical disk usage after dedup (FIEMAP-based, Linux only)",
+		},
+	},
+}
+
+func crioDedup(c *cli.Context) error {
+	ctx := c.Context
+
+	config, err := GetConfigFromContext(c)
+	if err != nil {
+		return fmt.Errorf("unable to load configuration: %w", err)
+	}
+
+	store, err := config.GetStore()
+	if err != nil {
+		return fmt.Errorf("unable to open storage: %w", err)
+	}
+
+	defer func() {
+		if _, err := store.Shutdown(true); err != nil {
+			log.Errorf(ctx, "Unable to shutdown storage: %v", err)
+		}
+	}()
+
+	showPhysicalUsage := c.Bool("physical-disk-usage")
+
+	return server.RunDedup(ctx, store, showPhysicalUsage)
+}

--- a/server/dedup.go
+++ b/server/dedup.go
@@ -1,0 +1,208 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path"
+
+	"go.podman.io/storage"
+	"golang.org/x/sys/unix"
+
+	"github.com/cri-o/cri-o/internal/log"
+	"github.com/cri-o/cri-o/utils"
+)
+
+// RunDedup runs a single storage deduplication pass using reflinks.
+// It calls store.Dedup with SHA256 hashing. If showPhysicalUsage is true,
+// measures real physical disk usage before and after dedup using FIEMAP (Linux only).
+func RunDedup(ctx context.Context, store storage.Store, showPhysicalUsage bool) error {
+	var beforeUsage uint64
+
+	// Measure physical usage before dedup
+	if showPhysicalUsage {
+		log.Infof(ctx, "Measuring physical disk usage before deduplication...")
+
+		usage, err := measurePhysicalUsage(ctx, store)
+		if err != nil {
+			log.Warnf(ctx, "Failed to measure initial disk usage: %v", err)
+		} else {
+			beforeUsage = usage
+			log.Infof(ctx, "Physical disk usage before dedup: %s", formatBytes(beforeUsage))
+		}
+	}
+
+	log.Infof(ctx, "Starting storage deduplication (this may take several minutes)...")
+
+	_, err := store.Dedup(storage.DedupArgs{
+		Options: storage.DedupOptions{
+			HashMethod: storage.DedupHashSHA256,
+		},
+	})
+	if err != nil {
+		if errors.Is(err, unix.ENOTSUP) || errors.Is(err, unix.EOPNOTSUPP) {
+			return fmt.Errorf("storage deduplication not supported on current filesystem: %w", err)
+		}
+
+		return fmt.Errorf("storage deduplication failed: %w", err)
+	}
+
+	log.Infof(ctx, "Storage deduplication complete")
+
+	// Measure physical usage after dedup and show savings
+	if showPhysicalUsage && beforeUsage > 0 {
+		log.Infof(ctx, "Measuring physical disk usage after deduplication...")
+
+		afterUsage, err := measurePhysicalUsage(ctx, store)
+		if err != nil {
+			log.Warnf(ctx, "Failed to measure final disk usage: %v", err)
+		} else {
+			log.Infof(ctx, "Physical disk usage after dedup: %s", formatBytes(afterUsage))
+
+			if beforeUsage > afterUsage {
+				saved := beforeUsage - afterUsage
+				pct := float64(saved) / float64(beforeUsage) * 100
+				log.Infof(ctx, "Space saved by deduplication: %s (%.1f%%)", formatBytes(saved), pct)
+			} else {
+				log.Infof(ctx, "No space savings detected (blocks may already be shared)")
+			}
+
+			// Show detailed breakdown (reuses afterUsage, only measures standard once)
+			if err := reportPhysicalUsage(ctx, store, afterUsage); err != nil {
+				log.Warnf(ctx, "Failed to report detailed physical disk usage: %v", err)
+			}
+		}
+	}
+
+	return nil
+}
+
+func measurePhysicalUsage(_ context.Context, store storage.Store) (uint64, error) {
+	rootPath := store.GraphRoot()
+	imagePath := store.ImageStore()
+	storageDriver := store.GraphDriverName()
+
+	var totalReal uint64
+
+	// When imagePath is empty, everything is under rootPath
+	// When imagePath is set, rootPath has containers, imagePath has images
+	if imagePath == "" {
+		// Single root: measure images directory only
+		imagesPath := path.Join(rootPath, storageDriver+"-images")
+
+		realBytes, _, err := utils.GetRealPhysicalUsage(imagesPath)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get real usage for %s: %w", imagesPath, err)
+		}
+
+		totalReal += realBytes
+	} else {
+		// Split layout: measure both containers and images
+		containersPath := path.Join(rootPath, storageDriver+"-containers")
+
+		realBytes, _, err := utils.GetRealPhysicalUsage(containersPath)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get real usage for %s: %w", containersPath, err)
+		}
+
+		totalReal += realBytes
+
+		imagesPath := path.Join(imagePath, storageDriver+"-images")
+
+		realBytes, _, err = utils.GetRealPhysicalUsage(imagesPath)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get real usage for %s: %w", imagesPath, err)
+		}
+
+		totalReal += realBytes
+	}
+
+	return totalReal, nil
+}
+
+func reportPhysicalUsage(ctx context.Context, store storage.Store, totalRealUsage uint64) error {
+	rootPath := store.GraphRoot()
+	imagePath := store.ImageStore()
+	storageDriver := store.GraphDriverName()
+
+	log.Infof(ctx, "")
+	log.Infof(ctx, "=== Detailed Physical Disk Usage (FIEMAP - Reflink-Aware) ===")
+	log.Infof(ctx, "Storage driver: %s", storageDriver)
+	log.Infof(ctx, "Graph root: %s", rootPath)
+
+	var totalStandard uint64
+
+	// When imagePath is empty, everything is under rootPath
+	// When imagePath is set, rootPath has containers, imagePath has images
+	if imagePath == "" {
+		// Single root: measure standard bytes for images directory only
+		imagesPath := path.Join(rootPath, storageDriver+"-images")
+
+		log.Infof(ctx, "")
+		log.Infof(ctx, "Image storage: %s", imagesPath)
+
+		standardBytes, _, err := utils.GetDiskUsageStats(imagesPath)
+		if err != nil {
+			return fmt.Errorf("failed to get standard usage for %s: %w", imagesPath, err)
+		}
+
+		totalStandard += standardBytes
+	} else {
+		// Split layout: measure standard bytes for both containers and images
+		containersPath := path.Join(rootPath, storageDriver+"-containers")
+
+		log.Infof(ctx, "")
+		log.Infof(ctx, "Container storage: %s", containersPath)
+
+		standardBytes, _, err := utils.GetDiskUsageStats(containersPath)
+		if err != nil {
+			return fmt.Errorf("failed to get standard usage for %s: %w", containersPath, err)
+		}
+
+		totalStandard += standardBytes
+
+		imagesPath := path.Join(imagePath, storageDriver+"-images")
+
+		log.Infof(ctx, "")
+		log.Infof(ctx, "Image storage: %s", imagesPath)
+
+		standardBytes, _, err = utils.GetDiskUsageStats(imagesPath)
+		if err != nil {
+			return fmt.Errorf("failed to get standard usage for %s: %w", imagesPath, err)
+		}
+
+		totalStandard += standardBytes
+	}
+
+	// Summary
+	log.Infof(ctx, "")
+	log.Infof(ctx, "=== Summary ===")
+
+	saved := int64(totalStandard) - int64(totalRealUsage)
+	if saved > 0 {
+		pct := float64(saved) / float64(totalStandard) * 100
+		log.Infof(ctx, "Standard reporting (stat.Blocks): %s", formatBytes(totalStandard))
+		log.Infof(ctx, "Real physical usage (FIEMAP):     %s", formatBytes(totalRealUsage))
+		log.Infof(ctx, "Shared blocks from reflinks:      %s (%.1f%%)", formatBytes(uint64(saved)), pct)
+	} else {
+		log.Infof(ctx, "Total physical usage: %s", formatBytes(totalRealUsage))
+		log.Infof(ctx, "No shared blocks detected (standard and FIEMAP match)")
+	}
+
+	return nil
+}
+
+func formatBytes(bytes uint64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+
+	div, exp := uint64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+
+	return fmt.Sprintf("%.2f %ciB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/server/dedup_test.go
+++ b/server/dedup_test.go
@@ -1,0 +1,84 @@
+package server_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	graphdriver "go.podman.io/storage/drivers"
+	"go.uber.org/mock/gomock"
+	"golang.org/x/sys/unix"
+
+	"github.com/cri-o/cri-o/server"
+)
+
+var _ = t.Describe("Dedup", func() {
+	// Prepare the sut
+	BeforeEach(beforeEach)
+	AfterEach(afterEach)
+
+	t.Describe("RunDedup", func() {
+		It("should succeed when dedup saves bytes", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{Deduped: 1024}, nil)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock, false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should succeed when dedup has no savings", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{Deduped: 0}, nil)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock, false)
+
+			// Then
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		It("should return error on ENOTSUP", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{}, unix.ENOTSUP)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not supported"))
+		})
+
+		It("should return error on EOPNOTSUPP", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{}, unix.EOPNOTSUPP)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("not supported"))
+		})
+
+		It("should return error on other failures", func() {
+			// Given
+			storeMock.EXPECT().Dedup(gomock.Any()).
+				Return(graphdriver.DedupResult{}, t.TestError)
+
+			// When
+			err := server.RunDedup(context.Background(), storeMock, false)
+
+			// Then
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(ContainSubstring("failed"))
+		})
+	})
+})

--- a/test/dedup.bats
+++ b/test/dedup.bats
@@ -1,0 +1,86 @@
+#!/usr/bin/env bats
+
+load helpers
+
+function setup() {
+	setup_test
+}
+
+function teardown() {
+	cleanup_test
+}
+
+@test "dedup: crio dedup command succeeds with populated storage" {
+	start_crio
+
+	# Populate storage with images
+	crictl pull "$IMAGE_LIST"
+
+	# Stop crio before running dedup (dedup should run while crio is stopped)
+	stop_crio
+
+	run "$CRIO_BINARY_PATH" \
+		-c "$CRIO_CONFIG" \
+		-d "$CRIO_CONFIG_DIR" \
+		dedup
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Starting storage deduplication"* ]]
+	[[ "$output" == *"Storage deduplication complete"* ]]
+
+	# Dedup may or may not find duplicates to deduplicate - both are valid outcomes
+	# The important thing is it completes successfully
+}
+
+@test "dedup: crio dedup with --physical-disk-usage on populated storage" {
+	start_crio
+
+	# Populate storage with images
+	crictl pull "$IMAGE_LIST"
+
+	# Stop crio before running dedup
+	stop_crio
+
+	run "$CRIO_BINARY_PATH" \
+		-c "$CRIO_CONFIG" \
+		-d "$CRIO_CONFIG_DIR" \
+		dedup --physical-disk-usage
+
+	[ "$status" -eq 0 ]
+	[[ "$output" == *"Starting storage deduplication"* ]]
+	[[ "$output" == *"Storage deduplication complete"* ]]
+	[[ "$output" == *"Measuring physical disk usage before deduplication"* ]]
+	[[ "$output" == *"Measuring physical disk usage after deduplication"* ]]
+	[[ "$output" == *"Physical disk usage"* ]]
+
+	# Should show either savings or "No space savings detected"
+	# Both are valid outcomes depending on whether dedup found duplicates
+}
+
+@test "dedup: server remains functional after dedup on populated storage" {
+	start_crio
+
+	# Populate storage with images and containers
+	crictl pull "$IMAGE_LIST"
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+
+	# Stop crio and run dedup
+	stop_crio
+
+	run "$CRIO_BINARY_PATH" \
+		-c "$CRIO_CONFIG" \
+		-d "$CRIO_CONFIG_DIR" \
+		dedup
+
+	[ "$status" -eq 0 ]
+
+	# Restart and verify server still works
+	start_crio
+
+	# Verify we can still create and run pods after dedup
+	pod_id=$(crictl runp "$TESTDATA"/sandbox_config.json)
+	crictl stopp "$pod_id"
+	crictl rmp "$pod_id"
+}

--- a/utils/filesystem_fiemap_linux.go
+++ b/utils/filesystem_fiemap_linux.go
@@ -1,0 +1,157 @@
+//go:build linux
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"syscall"
+	"unsafe"
+)
+
+// GetRealPhysicalUsage returns actual disk usage accounting for shared extents (reflinks).
+// This uses the FIEMAP ioctl to get physical extent mappings and tracks which blocks
+// are shared between files to avoid double-counting deduplicated data.
+//
+// This is significantly more expensive than GetDiskUsageStats as it requires FIEMAP
+// ioctl calls for every regular file. Use this when accurate reflink-aware reporting
+// is critical (e.g., when containers-storage dedup is active).
+//
+// Returns bytes of unique physical blocks and inode count.
+func GetRealPhysicalUsage(path string) (uniqueBytes, inodeCount uint64, err error) {
+	seenExtents := make(map[uint64]uint64)
+
+	err = filepath.Walk(path, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			// Skip files that disappeared during traversal
+			if os.IsNotExist(err) {
+				return nil
+			}
+
+			return err
+		}
+
+		inodeCount++
+
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		extents, err := getFileExtents(p)
+		if err != nil {
+			if sys := info.Sys(); sys != nil {
+				if stat, ok := sys.(*syscall.Stat_t); ok {
+					uniqueBytes += uint64(stat.Blocks) * 512
+				} else {
+					uniqueBytes += uint64(info.Size())
+				}
+			} else {
+				uniqueBytes += uint64(info.Size())
+			}
+
+			return nil
+		}
+
+		for _, ext := range extents {
+			if ext.Physical == 0 {
+				continue
+			}
+
+			if existingLen, seen := seenExtents[ext.Physical]; seen {
+				if ext.Length > existingLen {
+					uniqueBytes += ext.Length - existingLen
+					seenExtents[ext.Physical] = ext.Length
+				}
+			} else {
+				uniqueBytes += ext.Length
+				seenExtents[ext.Physical] = ext.Length
+			}
+		}
+
+		return nil
+	})
+
+	return uniqueBytes, inodeCount, err
+}
+
+// FiemapExtent represents a single extent from FIEMAP.
+type FiemapExtent struct {
+	Logical  uint64
+	Physical uint64
+	Length   uint64
+	Flags    uint32
+}
+
+func getFileExtents(path string) ([]FiemapExtent, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	stat, err := f.Stat()
+	if err != nil {
+		return nil, err
+	}
+
+	if stat.Size() == 0 {
+		return nil, nil
+	}
+
+	const (
+		fiemapMaxExtents = 512
+		fiemapFlagSync   = 0x00000001
+	)
+
+	type fiemapExtent struct {
+		feLogical  uint64
+		fePhysical uint64
+		feLength   uint64
+		_          [2]uint64
+		feFlags    uint32
+		_          [3]uint32
+	}
+
+	type fiemap struct {
+		fmStart         uint64
+		fmLength        uint64
+		fmFlags         uint32
+		fmMappedExtents uint32
+		fmExtentCount   uint32
+		_               uint32
+		fmExtents       [fiemapMaxExtents]fiemapExtent
+	}
+
+	var fm fiemap
+
+	fm.fmStart = 0
+	fm.fmLength = uint64(stat.Size())
+	fm.fmFlags = fiemapFlagSync
+	fm.fmExtentCount = fiemapMaxExtents
+
+	const FS_IOC_FIEMAP = 0xC020660B
+
+	_, _, errno := syscall.Syscall(
+		syscall.SYS_IOCTL,
+		f.Fd(),
+		FS_IOC_FIEMAP,
+		uintptr(unsafe.Pointer(&fm)),
+	)
+
+	if errno != 0 {
+		return nil, fmt.Errorf("FIEMAP ioctl failed: %w", errno)
+	}
+
+	extents := make([]FiemapExtent, fm.fmMappedExtents)
+	for i := range fm.fmMappedExtents {
+		extents[i] = FiemapExtent{
+			Logical:  fm.fmExtents[i].feLogical,
+			Physical: fm.fmExtents[i].fePhysical,
+			Length:   fm.fmExtents[i].feLength,
+			Flags:    fm.fmExtents[i].feFlags,
+		}
+	}
+
+	return extents, nil
+}

--- a/utils/filesystem_fiemap_unsupported.go
+++ b/utils/filesystem_fiemap_unsupported.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package utils
+
+import "fmt"
+
+// GetRealPhysicalUsage is not supported on non-Linux platforms.
+func GetRealPhysicalUsage(path string) (uniqueBytes, inodeCount uint64, err error) {
+	return 0, 0, fmt.Errorf("GetRealPhysicalUsage is only supported on Linux")
+}


### PR DESCRIPTION
## Summary

Adds on-demand storage deduplication command with optional FIEMAP-based physical disk usage measurement to show real space savings from reflinks.

**Command-only approach** (no config option):
- CLI command: `crio dedup` for manual deduplication
- No automatic startup dedup
- No `enable_storage_dedup` config option

## New Features

### `crio dedup` command
Runs storage deduplication on demand while CRI-O is stopped:
```bash
crio dedup
```

### `--physical-disk-usage` flag
Measures real disk usage before and after dedup using FIEMAP ioctl to detect shared blocks from reflinks:
```bash
crio dedup --physical-disk-usage
```

Shows actual space savings:
```
Measuring physical disk usage before deduplication...
Physical disk usage before dedup: 176.50 MiB
Starting storage deduplication (this may take several minutes)...
Storage deduplication complete
Measuring physical disk usage after deduplication...
Physical disk usage after dedup: 131.28 MiB
Space saved by deduplication: 45.22 MiB (25.6%)
```

## Implementation

- `internal/criocli/dedup.go`: CLI command with `-p` flag
- `server/dedup.go`: RunDedup() with before/after FIEMAP measurement
- `utils/filesystem_fiemap_linux.go`: FIEMAP ioctl for detecting reflink sharing
- `utils/filesystem_fiemap_unsupported.go`: Stub for non-Linux platforms
- `test/dedup.bats`: Integration tests on populated storage
- `completions/`: Added dedup subcommand to bash/fish/zsh

## Requirements

- Filesystem with reflink support (XFS with `reflink=1`, Btrfs)
- Linux kernel with FIEMAP support (2.6.28+) for `--physical-disk-usage`
- CRI-O should be stopped when running this command

## Testing

```bash
make localintegration TESTFLAGS="dedup.bats"
```

🤖 Generated with Claude Code