### PR TITLE
UPSTREAM: <carry>: Add OpenShift downstream RPM spec file to release-4.23

### DIFF
--- a/contrib/systemd/crio.service
+++ b/contrib/systemd/crio.service
@@ -23,7 +23,6 @@ OOMScoreAdjust=-999
 TimeoutStartSec=0
 Restart=on-failure
 RestartSec=10
-WatchdogSec=60s
 
 [Install]
 WantedBy=multi-user.target

--- a/cri-o.spec
+++ b/cri-o.spec
@@ -1,0 +1,242 @@
+%global with_debug 1
+
+%if 0%{?with_debug}
+%global _find_debuginfo_dwz_opts %{nil}
+%global _dwz_low_mem_die_limit 0
+%else
+%global debug_package %{nil}
+%endif
+
+%global import_path github.com/cri-o/cri-o
+
+# https://github.com/cri-o/cri-o/issues/8860
+# RHEL 9 go-rpm-macros patches out %%{?__golang_extldflags} from %%gobuild,
+# so we must override the macro to inject -Wl,-z,undefs directly.
+%if 0%{?rhel} && 0%{?rhel} < 10 && ! 0%{?fedora}
+%define gobuild(o:) go build -buildmode pie -compiler gc -tags="rpm_crashtraceback libtrust_openssl ${BUILDTAGS:-}" -ldflags "${LDFLAGS:-} -compressdwarf=false -B 0x$(head -c20 /dev/urandom|od -An -tx1|tr -d ' \\n') -extldflags '%__global_ldflags -Wl,-z,undefs'" -a -v -x %{?**};
+%else
+%global __golang_extldflags -Wl,-z,undefs
+%endif
+
+%if 0%{?rhel} >= 10
+%global sequoia 1
+%endif
+
+%global service_name crio
+
+%{!?commit:
+# DO NOT MODIFY: the value on the line below is sed-like replaced by openshift/doozer
+%global commit 5d8e3464d8ff2d88644b396bf3b938dfa05222ac
+}
+%global shortcommit %(c=%{commit}; echo ${c:0:7})
+
+%if ! 0%{?os_git_vars:1}
+# DO NOT MODIFY: the value on the line below is sed-like replaced by openshift/doozer
+%global os_git_vars OS_GIT_VERSION='' OS_GIT_COMMIT='' OS_GIT_TREE_STATE=''
+%endif
+
+%{!?version: %global version 0.0.1}
+%{!?release: %global release 1}
+
+Name:           cri-o
+Version:        %{version}
+Release:        %{release}%{?dist}
+Summary:        Kubernetes Container Runtime Interface for OCI-based containers
+License:        ASL 2.0
+URL:            https://%{import_path}
+
+Source0:        https://%{import_path}/archive/%{commit}/%{name}-%{version}.tar.gz
+
+# If go_arches not defined fall through to implicit golang archs
+%if 0%{?go_arches:1}
+ExclusiveArch:  %{go_arches}
+%else
+ExclusiveArch:  x86_64 aarch64 ppc64le s390x
+%endif
+
+BuildRequires:  golang
+BuildRequires:  git
+BuildRequires:  glib2-devel
+BuildRequires:  glibc-static
+BuildRequires:  go-md2man
+BuildRequires:  gpgme-devel
+BuildRequires:  libassuan-devel
+BuildRequires:  libseccomp-devel
+BuildRequires:  pkgconfig(systemd)
+BuildRequires:  systemd-rpm-macros
+%if %{undefined rhel} || 0%{?rhel} >= 10
+BuildRequires:  go-rpm-macros
+%endif
+
+Requires:       shadow-utils
+Requires(pre):  container-selinux
+Requires:       skopeo-containers >= 1:0.1.40-1
+Recommends:     (runc >= 1.0.0-61.rc8 or crun)
+Obsoletes:      ocid <= 0.3
+Provides:       ocid = %{version}-%{release}
+Provides:       %{service_name} = %{version}-%{release}
+Requires:       conmon >= 2.0.2-2
+%if %{defined sequoia}
+Requires:       podman-sequoia
+%endif
+%{?sysusers_requires_compat}
+
+%description
+%{summary}
+
+%prep
+%autosetup -Sgit -n %{name}-%{version}
+sed -i 's/\.gopathok //' Makefile
+sed -i 's/%{version}/%{version}-%{release}/' internal/version/version.go
+sed -i 's/\/local//' contrib/systemd/%{service_name}.service
+
+%build
+mkdir _output
+pushd _output
+mkdir -p src/github.com/{cri-o,opencontainers}
+ln -s $(dirs +1 -l) src/%{import_path}
+popd
+
+ln -s vendor src
+export GOPATH=$(pwd)/_output:$(pwd)
+export BUILDTAGS="selinux seccomp exclude_graphdriver_devicemapper exclude_graphdriver_btrfs containers_image_ostree_stub"
+%if %{defined sequoia}
+export BUILDTAGS="$BUILDTAGS containers_image_sequoia"
+%endif
+export GO111MODULE=off
+# https://bugzilla.redhat.com/show_bug.cgi?id=1825623
+export VERSION=%{version}
+
+# build crio
+%gobuild -o bin/%{service_name} %{import_path}/cmd/%{service_name}
+
+# build pinns and docs
+%{__make} bin/pinns
+GO_MD2MAN=go-md2man %{__make} docs
+
+%install
+./bin/%{service_name} \
+      --selinux \
+      --cni-plugin-dir "/var/lib/cni/bin" \
+      --cgroup-manager "systemd" \
+      config > %{service_name}.conf
+
+make PREFIX=%{buildroot}%{_prefix} DESTDIR=%{buildroot} \
+            install.bin-nobuild \
+            install.completions \
+            install.config-nobuild \
+            install.man-nobuild \
+            install.systemd
+
+# Remove CRI-O wipe service unit
+rm %{buildroot}%{_prefix}/lib/systemd/system/%{service_name}-wipe.service
+
+# Install seccomp.json
+install -D -p -m 0644 openshift/rpm/seccomp.json %{buildroot}%{_sysconfdir}/%{service_name}/seccomp.json
+install -dp %{buildroot}%{_sharedstatedir}/containers
+install -dp %{buildroot}%{_libexecdir}/%{service_name}
+install -dp %{buildroot}%{_sharedstatedir}/cni/bin
+install -dp %{buildroot}%{_sysconfdir}/kubernetes/cni/net.d
+install -dp %{buildroot}%{_datadir}/containers/oci/hooks.d
+install -dp %{buildroot}/opt/cni/bin
+install -D -p -m 0644 openshift/rpm/unshare.json %{buildroot}%{_libexecdir}/%{service_name}/unshare.json
+
+# Install cri-o.tmpfiles
+install -D -p -m 0644 openshift/rpm/cri-o.tmpfiles %{buildroot}%{_tmpfilesdir}/%{service_name}.conf
+
+# Install cri-o.sysusers
+install -D -p -m 0644 openshift/rpm/cri-o.sysusers %{buildroot}%{_sysusersdir}/%{service_name}.conf
+
+install -dp %{buildroot}/%{_unitdir}/irqbalance.service.d
+install -m 644 openshift/rpm/restart-limits.conf %{buildroot}/%{_unitdir}/irqbalance.service.d/restart-limits.conf
+
+# Install cri-o rootless containers user update service
+cat > %{service_name}-subid.service <<'EOF'
+
+[Unit]
+Description=Update user for rootless containers
+Before=crio.service
+
+[Service]
+Type=oneshot
+Environment="ROOTLESS_USER=containers"
+Environment="ROOTLESS_SUBUIDS=200000-16199999"
+Environment="ROOTLESS_SUBGIDS=200000-16199999"
+ExecCondition=/bin/bash -c 'if ! /usr/bin/getent -i passwd $ROOTLESS_USER >/dev/null 2>&1 ; then exit 1 ; else exit 0 ; fi'
+ExecCondition=/bin/bash -c 'if /usr/bin/grep -q $ROOTLESS_USER /etc/subuid ; then exit 1 ; else exit 0 ; fi'
+ExecStart=/usr/sbin/usermod --add-subuids $ROOTLESS_SUBUIDS --add-subgids $ROOTLESS_SUBGIDS $ROOTLESS_USER
+
+[Install]
+WantedBy=multi-user.target crio.service
+EOF
+
+install -D -p -m 0644 %{service_name}-subid.service %{buildroot}%{_unitdir}/%{service_name}-subid.service
+
+cat > %{service_name}-subid.preset <<'EOF'
+enable crio-subid.service
+EOF
+
+install -D -p -m 0644 %{service_name}-subid.preset %{buildroot}%{_presetdir}/50-%{service_name}-subid.preset
+
+%check
+%if 0%{?with_check}
+export GOPATH=%{buildroot}%{gopath}:$(pwd)/Godeps/_workspace:%{gopath}
+%endif
+
+%pre
+%sysusers_create_compat openshift/rpm/cri-o.sysusers
+
+%post
+%systemd_post %{service_name}
+%systemd_post %{service_name}-subid
+%tmpfiles_create %{_tmpfilesdir}/%{service_name}.conf
+
+%preun
+%systemd_preun %{service_name}
+%systemd_preun %{service_name}-subid
+
+%postun
+%systemd_postun_with_restart %{service_name}
+%systemd_postun %{service_name}-subid
+
+%{!?_licensedir:%global license %doc}
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/%{service_name}
+%{_bindir}/pinns
+%{_mandir}/man5/%{service_name}.conf*5*
+%{_mandir}/man8/%{service_name}*.8*
+%dir %{_sysconfdir}/%{service_name}
+%config(noreplace) %{_sysconfdir}/%{service_name}/%{service_name}.conf
+%config(noreplace) %{_sysconfdir}/%{service_name}/seccomp.json
+%config(noreplace) %{_sysconfdir}/crictl.yaml
+%{_unitdir}/%{service_name}.service
+%{_unitdir}/%{service_name}-subid.service
+%{_presetdir}/50-%{service_name}-subid.preset
+%dir %{_sharedstatedir}/containers
+%dir %{_sharedstatedir}/cni
+%dir %{_sharedstatedir}/cni/bin
+%dir %{_sysconfdir}/kubernetes
+%dir %{_sysconfdir}/kubernetes/cni
+%dir %{_sysconfdir}/kubernetes/cni/net.d
+%dir %{_datadir}/containers
+%dir %{_datadir}/containers/oci
+%dir %{_datadir}/containers/oci/hooks.d
+%dir /opt/cni
+%dir /opt/cni/bin
+%dir %{_datadir}/oci-umount
+%dir %{_datadir}/oci-umount/oci-umount.d
+%dir %{_libexecdir}/%{service_name}
+%{_libexecdir}/%{service_name}/unshare.json
+%{_datadir}/oci-umount/oci-umount.d/%{service_name}-umount.conf
+%{_datadir}/bash-completion/completions/%{service_name}*
+%{_datadir}/fish/completions/%{service_name}*.fish
+%{_datadir}/zsh/site-functions/_%{service_name}*
+%{_tmpfilesdir}/%{service_name}.conf
+%{_sysusersdir}/%{service_name}.conf
+%dir %{_unitdir}/irqbalance.service.d
+%{_unitdir}/irqbalance.service.d/restart-limits.conf
+
+%changelog

--- a/hack/build-rpms.sh
+++ b/hack/build-rpms.sh
@@ -11,7 +11,7 @@ os::util::ensure::system_binary_exists createrepo
 
 os::build::rpm::get_nvra_vars
 
-OS_RPM_SPECFILE="$(find "${OS_ROOT}" -name *cri-o.spec)"
+OS_RPM_SPECFILE="${OS_ROOT}/contrib/test/ci/cri-o.spec"
 OS_RPM_SPEC="$(rpmspec -q --qf '%{name}\n' "${OS_RPM_SPECFILE}")"
 OS_RPM_NAME="$(echo "$OS_RPM_SPEC" | head -1)"
 

--- a/openshift/rpm/Containerfile.rpmbuild
+++ b/openshift/rpm/Containerfile.rpmbuild
@@ -1,0 +1,27 @@
+FROM registry.fedoraproject.org/fedora:42
+
+RUN dnf install -y \
+        rpm-build \
+        rpmdevtools \
+        dnf-plugins-core \
+        git \
+        glib2-devel \
+        glibc-static \
+        go-md2man \
+        gpgme-devel \
+        libassuan-devel \
+        libseccomp-devel \
+        systemd-devel \
+        systemd-rpm-macros \
+        go-rpm-macros \
+        make \
+        createrepo_c \
+    && dnf clean all
+
+RUN GO_VERSION=$(curl -sSfL "https://go.dev/VERSION?m=text" | head -n1) \
+    && curl -sSfL -o- "https://go.dev/dl/${GO_VERSION}.linux-amd64.tar.gz" | tar xfz - -C /usr/local
+ENV PATH=/usr/local/go/bin:$PATH
+
+RUN rpmdev-setuptree
+
+WORKDIR /root/rpmbuild

--- a/openshift/rpm/cri-o.sysusers
+++ b/openshift/rpm/cri-o.sysusers
@@ -1,0 +1,2 @@
+g containers -
+u containers - "User for rootless containers" /nonexistent /sbin/nologin

--- a/openshift/rpm/cri-o.tmpfiles
+++ b/openshift/rpm/cri-o.tmpfiles
@@ -1,0 +1,1 @@
+L /var/lib/kubelet/seccomp/profiles/unshare.json - - - - /usr/libexec/crio/unshare.json

--- a/openshift/rpm/restart-limits.conf
+++ b/openshift/rpm/restart-limits.conf
@@ -1,0 +1,10 @@
+# cri-o high performance runtime handler reconfigures and restarts irqbalance
+# after every container with pinned cpus and moved interrupts is created.
+# Systemd does not like this and will block further restarts when the
+# StartLimitBurst (default 5) is crossed within the default timeout (10s).
+# That is too strict as during system startup many such containers might
+# be launched.
+# Install this to /etc/systemd/system/irqbalance.service.d/restart-limits.conf
+# to prevent systemd from blocking the necessary restarts.
+[Unit]
+StartLimitBurst=100

--- a/openshift/rpm/seccomp.json
+++ b/openshift/rpm/seccomp.json
@@ -1,0 +1,774 @@
+{
+	"defaultAction": "SCMP_ACT_ERRNO",
+	"archMap": [
+		{
+			"architecture": "SCMP_ARCH_X86_64",
+			"subArchitectures": [
+				"SCMP_ARCH_X86",
+				"SCMP_ARCH_X32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_AARCH64",
+			"subArchitectures": [
+				"SCMP_ARCH_ARM"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPS64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPS",
+				"SCMP_ARCH_MIPS64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64N32"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_MIPSEL64N32",
+			"subArchitectures": [
+				"SCMP_ARCH_MIPSEL",
+				"SCMP_ARCH_MIPSEL64"
+			]
+		},
+		{
+			"architecture": "SCMP_ARCH_S390X",
+			"subArchitectures": [
+				"SCMP_ARCH_S390"
+			]
+		}
+	],
+	"syscalls": [
+		{
+			"names": [
+				"_llseek",
+				"_newselect",
+				"accept",
+				"accept4",
+				"access",
+				"adjtimex",
+				"alarm",
+				"bind",
+				"brk",
+				"capget",
+				"capset",
+				"chdir",
+				"chmod",
+				"chown",
+				"chown32",
+				"clock_getres",
+				"clock_gettime",
+				"clock_nanosleep",
+				"close",
+				"connect",
+				"copy_file_range",
+				"creat",
+				"dup",
+				"dup2",
+				"dup3",
+				"epoll_create",
+				"epoll_create1",
+				"epoll_ctl",
+				"epoll_ctl_old",
+				"epoll_pwait",
+				"epoll_wait",
+				"epoll_wait_old",
+				"eventfd",
+				"eventfd2",
+				"execve",
+				"execveat",
+				"exit",
+				"exit_group",
+				"faccessat",
+				"fadvise64",
+				"fadvise64_64",
+				"fallocate",
+				"fanotify_mark",
+				"fchdir",
+				"fchmod",
+				"fchmodat",
+				"fchown",
+				"fchown32",
+				"fchownat",
+				"fcntl",
+				"fcntl64",
+				"fdatasync",
+				"fgetxattr",
+				"flistxattr",
+				"flock",
+				"fork",
+				"fremovexattr",
+				"fsetxattr",
+				"fstat",
+				"fstat64",
+				"fstatat64",
+				"fstatfs",
+				"fstatfs64",
+				"fsync",
+				"ftruncate",
+				"ftruncate64",
+				"futex",
+				"futimesat",
+				"get_robust_list",
+				"get_thread_area",
+				"getcpu",
+				"getcwd",
+				"getdents",
+				"getdents64",
+				"getegid",
+				"getegid32",
+				"geteuid",
+				"geteuid32",
+				"getgid",
+				"getgid32",
+				"getgroups",
+				"getgroups32",
+				"getitimer",
+				"getpeername",
+				"getpgid",
+				"getpgrp",
+				"getpid",
+				"getppid",
+				"getpriority",
+				"getrandom",
+				"getresgid",
+				"getresgid32",
+				"getresuid",
+				"getresuid32",
+				"getrlimit",
+				"getrusage",
+				"getsid",
+				"getsockname",
+				"getsockopt",
+				"gettid",
+				"gettimeofday",
+				"getuid",
+				"getuid32",
+				"getxattr",
+				"inotify_add_watch",
+				"inotify_init",
+				"inotify_init1",
+				"inotify_rm_watch",
+				"io_cancel",
+				"io_destroy",
+				"io_getevents",
+				"io_setup",
+				"io_submit",
+				"ioctl",
+				"ioprio_get",
+				"ioprio_set",
+				"ipc",
+				"kill",
+				"lchown",
+				"lchown32",
+				"lgetxattr",
+				"link",
+				"linkat",
+				"listen",
+				"listxattr",
+				"llistxattr",
+				"lremovexattr",
+				"lseek",
+				"lsetxattr",
+				"lstat",
+				"lstat64",
+				"madvise",
+				"memfd_create",
+				"mincore",
+				"mkdir",
+				"mkdirat",
+				"mknod",
+				"mknodat",
+				"mlock",
+				"mlock2",
+				"mlockall",
+				"mmap",
+				"mmap2",
+				"mount",
+				"mprotect",
+				"mq_getsetattr",
+				"mq_notify",
+				"mq_open",
+				"mq_timedreceive",
+				"mq_timedsend",
+				"mq_unlink",
+				"mremap",
+				"msgctl",
+				"msgget",
+				"msgrcv",
+				"msgsnd",
+				"msync",
+				"munlock",
+				"munlockall",
+				"munmap",
+				"name_to_handle_at",
+				"nanosleep",
+				"newfstatat",
+				"open",
+				"openat",
+				"pause",
+				"pipe",
+				"pipe2",
+				"poll",
+				"ppoll",
+				"prctl",
+				"pread64",
+				"preadv",
+				"preadv2",
+				"prlimit64",
+				"pselect6",
+				"pwrite64",
+				"pwritev",
+				"pwritev2",
+				"read",
+				"readahead",
+				"readlink",
+				"readlinkat",
+				"readv",
+				"reboot",
+				"recv",
+				"recvfrom",
+				"recvmmsg",
+				"recvmsg",
+				"remap_file_pages",
+				"removexattr",
+				"rename",
+				"renameat",
+				"renameat2",
+				"restart_syscall",
+				"rmdir",
+				"rt_sigaction",
+				"rt_sigpending",
+				"rt_sigprocmask",
+				"rt_sigqueueinfo",
+				"rt_sigreturn",
+				"rt_sigsuspend",
+				"rt_sigtimedwait",
+				"rt_tgsigqueueinfo",
+				"sched_get_priority_max",
+				"sched_get_priority_min",
+				"sched_getaffinity",
+				"sched_getattr",
+				"sched_getparam",
+				"sched_getscheduler",
+				"sched_rr_get_interval",
+				"sched_setaffinity",
+				"sched_setattr",
+				"sched_setparam",
+				"sched_setscheduler",
+				"sched_yield",
+				"seccomp",
+				"select",
+				"semctl",
+				"semget",
+				"semop",
+				"semtimedop",
+				"send",
+				"sendfile",
+				"sendfile64",
+				"sendmmsg",
+				"sendmsg",
+				"sendto",
+				"set_robust_list",
+				"set_thread_area",
+				"set_tid_address",
+				"setfsgid",
+				"setfsgid32",
+				"setfsuid",
+				"setfsuid32",
+				"setgid",
+				"setgid32",
+				"setgroups",
+				"setgroups32",
+				"setitimer",
+				"setpgid",
+				"setpriority",
+				"setregid",
+				"setregid32",
+				"setresgid",
+				"setresgid32",
+				"setresuid",
+				"setresuid32",
+				"setreuid",
+				"setreuid32",
+				"setrlimit",
+				"setsid",
+				"setsockopt",
+				"setuid",
+				"setuid32",
+				"setxattr",
+				"shmat",
+				"shmctl",
+				"shmdt",
+				"shmget",
+				"shutdown",
+				"sigaltstack",
+				"signalfd",
+				"signalfd4",
+				"sigreturn",
+				"socket",
+				"socketcall",
+				"socketpair",
+				"splice",
+				"stat",
+				"stat64",
+				"statfs",
+				"statfs64",
+				"statx",
+				"symlink",
+				"symlinkat",
+				"sync",
+				"sync_file_range",
+				"syncfs",
+				"sysinfo",
+				"syslog",
+				"tee",
+				"tgkill",
+				"time",
+				"timer_create",
+				"timer_delete",
+				"timer_getoverrun",
+				"timer_gettime",
+				"timer_settime",
+				"timerfd_create",
+				"timerfd_gettime",
+				"timerfd_settime",
+				"times",
+				"tkill",
+				"truncate",
+				"truncate64",
+				"ugetrlimit",
+				"umask",
+				"umount",
+				"umount2",
+				"uname",
+				"unlink",
+				"unlinkat",
+				"unshare",
+				"utime",
+				"utimensat",
+				"utimes",
+				"vfork",
+				"vmsplice",
+				"wait4",
+				"waitid",
+				"waitpid",
+				"write",
+				"writev"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 0,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 8,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 131072,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 131080,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"personality"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 4294967295,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"sync_file_range2"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"ppc64le"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"arm_fadvise64_64",
+				"arm_sync_file_range",
+				"sync_file_range2",
+				"breakpoint",
+				"cacheflush",
+				"set_tls"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"arm",
+					"arm64"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"arch_prctl"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"modify_ldt"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"amd64",
+					"x32",
+					"x86"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"s390_pci_mmio_read",
+				"s390_pci_mmio_write",
+				"s390_runtime_instr"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"open_by_handle_at"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_DAC_READ_SEARCH"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"bpf",
+				"clone",
+				"fanotify_init",
+				"lookup_dcookie",
+				"mount",
+				"name_to_handle_at",
+				"perf_event_open",
+				"quotactl",
+				"setdomainname",
+				"sethostname",
+				"setns",
+				"umount",
+				"umount2",
+				"unshare"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"clone"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 0,
+					"value": 2080505856,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"comment": "",
+			"includes": {},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				],
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			}
+		},
+		{
+			"names": [
+				"clone"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [
+				{
+					"index": 1,
+					"value": 2080505856,
+					"valueTwo": 0,
+					"op": "SCMP_CMP_MASKED_EQ"
+				}
+			],
+			"comment": "s390 parameter ordering for clone is different",
+			"includes": {
+				"arches": [
+					"s390",
+					"s390x"
+				]
+			},
+			"excludes": {
+				"caps": [
+					"CAP_SYS_ADMIN"
+				]
+			}
+		},
+		{
+			"names": [
+				"reboot"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_BOOT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"chroot"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_CHROOT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"delete_module",
+				"init_module",
+				"finit_module",
+				"query_module"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_MODULE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"get_mempolicy",
+				"mbind",
+				"name_to_handle_at",
+				"set_mempolicy"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_NICE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"acct"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PACCT"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"kcmp",
+				"process_vm_readv",
+				"process_vm_writev",
+				"ptrace"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_PTRACE"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"iopl",
+				"ioperm"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_RAWIO"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"settimeofday",
+				"stime",
+				"clock_settime"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TIME"
+				]
+			},
+			"excludes": {}
+		},
+		{
+			"names": [
+				"vhangup"
+			],
+			"action": "SCMP_ACT_ALLOW",
+			"args": [],
+			"comment": "",
+			"includes": {
+				"caps": [
+					"CAP_SYS_TTY_CONFIG"
+				]
+			},
+			"excludes": {}
+		}
+	]
+}

--- a/openshift/rpm/unshare.json
+++ b/openshift/rpm/unshare.json
@@ -1,0 +1,1048 @@
+{
+  "defaultAction": "SCMP_ACT_ERRNO",
+  "defaultErrnoRet": 38,
+  "defaultErrno": "ENOSYS",
+  "archMap": [
+    {
+      "architecture": "SCMP_ARCH_X86_64",
+      "subArchitectures": [
+        "SCMP_ARCH_X86",
+        "SCMP_ARCH_X32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_AARCH64",
+      "subArchitectures": [
+        "SCMP_ARCH_ARM"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPS64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPS",
+        "SCMP_ARCH_MIPS64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64N32"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_MIPSEL64N32",
+      "subArchitectures": [
+        "SCMP_ARCH_MIPSEL",
+        "SCMP_ARCH_MIPSEL64"
+      ]
+    },
+    {
+      "architecture": "SCMP_ARCH_S390X",
+      "subArchitectures": [
+        "SCMP_ARCH_S390"
+      ]
+    }
+  ],
+  "syscalls": [
+    {
+      "names": [
+        "bdflush",
+        "io_pgetevents",
+        "kexec_file_load",
+        "kexec_load",
+        "migrate_pages",
+        "move_pages",
+        "nfsservctl",
+        "nice",
+        "oldfstat",
+        "oldlstat",
+        "oldolduname",
+        "oldstat",
+        "olduname",
+        "pciconfig_iobase",
+        "pciconfig_read",
+        "pciconfig_write",
+        "sgetmask",
+        "ssetmask",
+        "swapcontext",
+        "swapoff",
+        "swapon",
+        "sysfs",
+        "uselib",
+        "userfaultfd",
+        "ustat",
+        "vm86",
+        "vm86old",
+        "vmsplice"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {},
+      "errnoRet": 1,
+      "errno": "EPERM"
+    },
+    {
+      "names": [
+        "_llseek",
+        "_newselect",
+        "accept",
+        "accept4",
+        "access",
+        "adjtimex",
+        "alarm",
+        "bind",
+        "brk",
+        "capget",
+        "capset",
+        "chdir",
+        "chmod",
+        "chown",
+        "chown32",
+        "clock_adjtime",
+        "clock_adjtime64",
+        "clock_getres",
+        "clock_getres_time64",
+        "clock_gettime",
+        "clock_gettime64",
+        "clock_nanosleep",
+        "clock_nanosleep_time64",
+        "clone",
+        "clone3",
+        "close",
+        "close_range",
+        "connect",
+        "copy_file_range",
+        "creat",
+        "dup",
+        "dup2",
+        "dup3",
+        "epoll_create",
+        "epoll_create1",
+        "epoll_ctl",
+        "epoll_ctl_old",
+        "epoll_pwait",
+        "epoll_pwait2",
+        "epoll_wait",
+        "epoll_wait_old",
+        "eventfd",
+        "eventfd2",
+        "execve",
+        "execveat",
+        "exit",
+        "exit_group",
+        "faccessat",
+        "faccessat2",
+        "fadvise64",
+        "fadvise64_64",
+        "fallocate",
+        "fanotify_mark",
+        "fchdir",
+        "fchmod",
+        "fchmodat",
+        "fchown",
+        "fchown32",
+        "fchownat",
+        "fcntl",
+        "fcntl64",
+        "fdatasync",
+        "fgetxattr",
+        "flistxattr",
+        "flock",
+        "fork",
+        "fremovexattr",
+        "fsconfig",
+        "fsetxattr",
+        "fsmount",
+        "fsopen",
+        "fspick",
+        "fstat",
+        "fstat64",
+        "fstatat64",
+        "fstatfs",
+        "fstatfs64",
+        "fsync",
+        "ftruncate",
+        "ftruncate64",
+        "futex",
+        "futex_time64",
+        "futimesat",
+        "get_mempolicy",
+        "get_robust_list",
+        "get_thread_area",
+        "getcpu",
+        "getcwd",
+        "getdents",
+        "getdents64",
+        "getegid",
+        "getegid32",
+        "geteuid",
+        "geteuid32",
+        "getgid",
+        "getgid32",
+        "getgroups",
+        "getgroups32",
+        "getitimer",
+        "getpeername",
+        "getpgid",
+        "getpgrp",
+        "getpid",
+        "getppid",
+        "getpriority",
+        "getrandom",
+        "getresgid",
+        "getresgid32",
+        "getresuid",
+        "getresuid32",
+        "getrlimit",
+        "getrusage",
+        "getsid",
+        "getsockname",
+        "getsockopt",
+        "gettid",
+        "gettimeofday",
+        "getuid",
+        "getuid32",
+        "getxattr",
+        "inotify_add_watch",
+        "inotify_init",
+        "inotify_init1",
+        "inotify_rm_watch",
+        "io_cancel",
+        "io_destroy",
+        "io_getevents",
+        "io_setup",
+        "io_submit",
+        "ioctl",
+        "ioprio_get",
+        "ioprio_set",
+        "ipc",
+        "keyctl",
+        "kill",
+        "lchown",
+        "lchown32",
+        "lgetxattr",
+        "link",
+        "linkat",
+        "listen",
+        "listxattr",
+        "llistxattr",
+        "lremovexattr",
+        "lseek",
+        "lsetxattr",
+        "lstat",
+        "lstat64",
+        "madvise",
+        "mbind",
+        "membarrier",
+        "memfd_create",
+        "memfd_secret",
+        "mincore",
+        "mkdir",
+        "mkdirat",
+        "mknod",
+        "mknodat",
+        "mlock",
+        "mlock2",
+        "mlockall",
+        "mmap",
+        "mmap2",
+        "mount",
+        "mount_setattr",
+        "move_mount",
+        "mprotect",
+        "mq_getsetattr",
+        "mq_notify",
+        "mq_open",
+        "mq_timedreceive",
+        "mq_timedreceive_time64",
+        "mq_timedsend",
+        "mq_timedsend_time64",
+        "mq_unlink",
+        "mremap",
+        "msgctl",
+        "msgget",
+        "msgrcv",
+        "msgsnd",
+        "msync",
+        "munlock",
+        "munlockall",
+        "munmap",
+        "name_to_handle_at",
+        "nanosleep",
+        "newfstatat",
+        "open",
+        "open_tree",
+        "openat",
+        "openat2",
+        "pause",
+        "pidfd_getfd",
+        "pidfd_open",
+        "pidfd_send_signal",
+        "pipe",
+        "pipe2",
+        "pivot_root",
+        "pkey_alloc",
+        "pkey_free",
+        "pkey_mprotect",
+        "poll",
+        "ppoll",
+        "ppoll_time64",
+        "prctl",
+        "pread64",
+        "preadv",
+        "preadv2",
+        "prlimit64",
+        "process_mrelease",
+        "process_vm_readv",
+        "process_vm_writev",
+        "pselect6",
+        "pselect6_time64",
+        "ptrace",
+        "pwrite64",
+        "pwritev",
+        "pwritev2",
+        "read",
+        "readahead",
+        "readdir",
+        "readlink",
+        "readlinkat",
+        "readv",
+        "reboot",
+        "recv",
+        "recvfrom",
+        "recvmmsg",
+        "recvmmsg_time64",
+        "recvmsg",
+        "remap_file_pages",
+        "removexattr",
+        "rename",
+        "renameat",
+        "renameat2",
+        "restart_syscall",
+        "rmdir",
+        "rseq",
+        "rt_sigaction",
+        "rt_sigpending",
+        "rt_sigprocmask",
+        "rt_sigqueueinfo",
+        "rt_sigreturn",
+        "rt_sigsuspend",
+        "rt_sigtimedwait",
+        "rt_sigtimedwait_time64",
+        "rt_tgsigqueueinfo",
+        "sched_get_priority_max",
+        "sched_get_priority_min",
+        "sched_getaffinity",
+        "sched_getattr",
+        "sched_getparam",
+        "sched_getscheduler",
+        "sched_rr_get_interval",
+        "sched_rr_get_interval_time64",
+        "sched_setaffinity",
+        "sched_setattr",
+        "sched_setparam",
+        "sched_setscheduler",
+        "sched_yield",
+        "seccomp",
+        "select",
+        "semctl",
+        "semget",
+        "semop",
+        "semtimedop",
+        "semtimedop_time64",
+        "send",
+        "sendfile",
+        "sendfile64",
+        "sendmmsg",
+        "sendmsg",
+        "sendto",
+        "set_mempolicy",
+        "set_robust_list",
+        "set_thread_area",
+        "set_tid_address",
+        "setfsgid",
+        "setfsgid32",
+        "setfsuid",
+        "setfsuid32",
+        "setgid",
+        "setgid32",
+        "setgroups",
+        "setgroups32",
+        "setitimer",
+        "setns",
+        "setpgid",
+        "setpriority",
+        "setregid",
+        "setregid32",
+        "setresgid",
+        "setresgid32",
+        "setresuid",
+        "setresuid32",
+        "setreuid",
+        "setreuid32",
+        "setrlimit",
+        "setsid",
+        "setsockopt",
+        "setuid",
+        "setuid32",
+        "setxattr",
+        "shmat",
+        "shmctl",
+        "shmdt",
+        "shmget",
+        "shutdown",
+        "sigaction",
+        "sigaltstack",
+        "signal",
+        "signalfd",
+        "signalfd4",
+        "sigpending",
+        "sigprocmask",
+        "sigreturn",
+        "sigsuspend",
+        "socketcall",
+        "socketpair",
+        "splice",
+        "stat",
+        "stat64",
+        "statfs",
+        "statfs64",
+        "statx",
+        "symlink",
+        "symlinkat",
+        "sync",
+        "sync_file_range",
+        "syncfs",
+        "syscall",
+        "sysinfo",
+        "syslog",
+        "tee",
+        "tgkill",
+        "time",
+        "timer_create",
+        "timer_delete",
+        "timer_getoverrun",
+        "timer_gettime",
+        "timer_gettime64",
+        "timer_settime",
+        "timer_settime64",
+        "timerfd",
+        "timerfd_create",
+        "timerfd_gettime",
+        "timerfd_gettime64",
+        "timerfd_settime",
+        "timerfd_settime64",
+        "times",
+        "tkill",
+        "truncate",
+        "truncate64",
+        "ugetrlimit",
+        "umask",
+        "umount",
+        "umount2",
+        "uname",
+        "unlink",
+        "unlinkat",
+        "unshare",
+        "utime",
+        "utimensat",
+        "utimensat_time64",
+        "utimes",
+        "vfork",
+        "wait4",
+        "waitid",
+        "waitpid",
+        "write",
+        "writev"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 0,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 8,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131072,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 131080,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "personality"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 4294967295,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {}
+    },
+    {
+      "names": [
+        "sync_file_range2"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": [
+          "ppc64le"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "arm_fadvise64_64",
+        "arm_sync_file_range",
+        "breakpoint",
+        "cacheflush",
+        "set_tls",
+        "sync_file_range2"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": [
+          "arm",
+          "arm64"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "arch_prctl"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "modify_ldt"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": [
+          "amd64",
+          "x32",
+          "x86"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "s390_pci_mmio_read",
+        "s390_pci_mmio_write",
+        "s390_runtime_instr"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "arches": [
+          "s390",
+          "s390x"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "open_by_handle_at"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_DAC_READ_SEARCH"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "open_by_handle_at"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_DAC_READ_SEARCH"
+        ]
+      },
+      "errnoRet": 1,
+      "errno": "EPERM"
+    },
+    {
+      "names": [
+        "bpf",
+        "fanotify_init",
+        "lookup_dcookie",
+        "perf_event_open",
+        "quotactl",
+        "setdomainname",
+        "sethostname",
+        "setns"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "bpf",
+        "fanotify_init",
+        "lookup_dcookie",
+        "perf_event_open",
+        "quotactl",
+        "setdomainname",
+        "sethostname",
+        "setns"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_SYS_ADMIN"
+        ]
+      },
+      "errnoRet": 1,
+      "errno": "EPERM"
+    },
+    {
+      "names": [
+        "chroot"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_CHROOT"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "chroot"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_SYS_CHROOT"
+        ]
+      },
+      "errnoRet": 1,
+      "errno": "EPERM"
+    },
+    {
+      "names": [
+        "delete_module",
+        "finit_module",
+        "init_module",
+        "query_module"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_MODULE"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "delete_module",
+        "finit_module",
+        "init_module",
+        "query_module"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_SYS_MODULE"
+        ]
+      },
+      "errnoRet": 1,
+      "errno": "EPERM"
+    },
+    {
+      "names": [
+        "acct"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_PACCT"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "acct"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_SYS_PACCT"
+        ]
+      },
+      "errnoRet": 1,
+      "errno": "EPERM"
+    },
+    {
+      "names": [
+        "kcmp",
+        "process_madvise"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_PTRACE"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "kcmp",
+        "process_madvise"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_SYS_PTRACE"
+        ]
+      },
+      "errnoRet": 1,
+      "errno": "EPERM"
+    },
+    {
+      "names": [
+        "ioperm",
+        "iopl"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_RAWIO"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "ioperm",
+        "iopl"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_SYS_RAWIO"
+        ]
+      },
+      "errnoRet": 1,
+      "errno": "EPERM"
+    },
+    {
+      "names": [
+        "clock_settime",
+        "clock_settime64",
+        "settimeofday",
+        "stime"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_TIME"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "clock_settime",
+        "clock_settime64",
+        "settimeofday",
+        "stime"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_SYS_TIME"
+        ]
+      },
+      "errnoRet": 1,
+      "errno": "EPERM"
+    },
+    {
+      "names": [
+        "vhangup"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [],
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_SYS_TTY_CONFIG"
+        ]
+      },
+      "excludes": {}
+    },
+    {
+      "names": [
+        "vhangup"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_SYS_TTY_CONFIG"
+        ]
+      },
+      "errnoRet": 1,
+      "errno": "EPERM"
+    },
+    {
+      "names": [
+        "socket"
+      ],
+      "action": "SCMP_ACT_ERRNO",
+      "args": [
+        {
+          "index": 0,
+          "value": 16,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        },
+        {
+          "index": 2,
+          "value": 9,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_EQ"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_AUDIT_WRITE"
+        ]
+      },
+      "errnoRet": 22,
+      "errno": "EINVAL"
+    },
+    {
+      "names": [
+        "socket"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 2,
+          "value": 9,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_NE"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_AUDIT_WRITE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "socket"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 0,
+          "value": 16,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_NE"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_AUDIT_WRITE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "socket"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": [
+        {
+          "index": 2,
+          "value": 9,
+          "valueTwo": 0,
+          "op": "SCMP_CMP_NE"
+        }
+      ],
+      "comment": "",
+      "includes": {},
+      "excludes": {
+        "caps": [
+          "CAP_AUDIT_WRITE"
+        ]
+      }
+    },
+    {
+      "names": [
+        "socket"
+      ],
+      "action": "SCMP_ACT_ALLOW",
+      "args": null,
+      "comment": "",
+      "includes": {
+        "caps": [
+          "CAP_AUDIT_WRITE"
+        ]
+      },
+      "excludes": {}
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Cherry-picks the OpenShift downstream RPM packaging carry from main onto release-4.23 (cri-o.spec, openshift/rpm/*, and related WatchdogSec carry).
- Unblocks ART ocp4-scan-konflux for 4.23: rpms/cri-o.yml expects root cri-o.spec on release-4.23 (scan 54731).

## Test plan
- Confirm cri-o.spec exists at repo root on this branch
- After merge and priv sync, re-run build/ocp4-scan-konflux with VERSION=4.23
